### PR TITLE
Add Proxy Endpoints for salty-boy API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5917,6 +5917,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {
       "version": "7.0.0-beta.0",
       "dev": true,
@@ -8413,6 +8424,26 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -11853,6 +11884,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -14668,6 +14705,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.10.4",
+        "axios": "^1.7.2",
         "chalk": "^5.3.0",
         "graphql": "^16.9.0",
         "graphql-scalars": "^1.23.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "dependencies": {
     "@apollo/server": "^4.10.4",
+    "axios": "^1.7.2",
     "chalk": "^5.3.0",
     "graphql": "^16.9.0",
     "graphql-scalars": "^1.23.0",

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -3,10 +3,45 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.This scalar is serialized to a string in ISO 8601 format and parsed from a string in ISO 8601 format.
+"""
+scalar DateTimeISO
+
+type Fighter {
+  bestStreak: Int!
+  createdTime: DateTimeISO!
+  elo: Int!
+  id: ID!
+  lastUpdated: DateTimeISO!
+  name: String!
+  prevTier: String!
+  tier: String!
+  tierElo: Int!
+}
+
 type Item {
   color: String
   id: Float!
   name: String!
+}
+
+type Match {
+  betBlue: Float!
+  betRed: Float!
+  colour: String!
+  date: DateTimeISO!
+  fighterBlue: Fighter!
+  fighterBlueId: Int!
+  fighterRed: Fighter!
+  fighterRedId: Int!
+  id: ID!
+  matchFormat: String!
+  streakBlue: Int!
+  streakRed: Int!
+  tier: String!
+  winner: Fighter!
+  winnerId: Int!
 }
 
 type Mutation {
@@ -24,6 +59,8 @@ type Player {
 }
 
 type Query {
+  getFighter(id: Int!): Fighter!
+  getMatch(id: Int!): Match!
   item(id: Int!): Item!
   items: [Item!]!
   player(id: Int!): Player!

--- a/packages/api/src/dtos/SaltyBets/Fighter.ts
+++ b/packages/api/src/dtos/SaltyBets/Fighter.ts
@@ -1,0 +1,31 @@
+import { Field, ID, Int, ObjectType } from "type-graphql";
+
+@ObjectType()
+export class Fighter {
+  @Field(() => ID)
+  id: number;
+
+  @Field(() => Int)
+  bestStreak: number;
+
+  @Field(() => Date)
+  createdTime: Date;
+
+  @Field(() => Int)
+  elo: number;
+
+  @Field(() => Date)
+  lastUpdated: Date;
+
+  @Field(() => String)
+  name: string;
+
+  @Field(() => String)
+  prevTier: string;
+
+  @Field(() => String)
+  tier: string;
+
+  @Field(() => Int)
+  tierElo: number;
+}

--- a/packages/api/src/dtos/SaltyBets/Match.ts
+++ b/packages/api/src/dtos/SaltyBets/Match.ts
@@ -1,0 +1,50 @@
+import { Field, Float, ID, Int, ObjectType } from "type-graphql";
+import { Fighter } from "./Fighter";
+
+@ObjectType()
+export class Match {
+  @Field(() => Float)
+  betBlue: number;
+
+  @Field(() => Float)
+  betRed: number;
+
+  @Field(() => String)
+  colour: string;
+
+  @Field(() => Date)
+  date: Date;
+
+  @Field(() => Int)
+  fighterBlueId: number;
+
+  @Field(() => Fighter)
+  fighterBlue: Fighter;
+
+  @Field(() => Int)
+  fighterRedId: number;
+
+  @Field(() => Fighter)
+  fighterRed: Fighter;
+
+  @Field(() => ID)
+  id: number;
+
+  @Field(() => String)
+  matchFormat: string;
+
+  @Field(() => Int)
+  streakBlue: number;
+
+  @Field(() => Int)
+  streakRed: number;
+
+  @Field(() => String)
+  tier: string;
+
+  @Field(() => Int)
+  winnerId: number;
+
+  @Field(() => Fighter)
+  winner: Fighter;
+}

--- a/packages/api/src/resolvers/SaltyBets/Fighter.ts
+++ b/packages/api/src/resolvers/SaltyBets/Fighter.ts
@@ -6,6 +6,11 @@ import { SaltyBetsService } from "../../../utils/salty-boy/SaltyBetsService";
 
 @Resolver(Fighter)
 export class FighterResolver {
+  /**
+   * Gets a fighter from the salty-boy api given an id
+   * @param id id of the fighter to get
+   * @returns the given fighter
+   */
   @Query(() => Fighter)
   async getFighter(@Arg("id", () => Int) id: number) {
     logger.debug("getting fighter...");

--- a/packages/api/src/resolvers/SaltyBets/Fighter.ts
+++ b/packages/api/src/resolvers/SaltyBets/Fighter.ts
@@ -1,0 +1,20 @@
+import { Arg, Int, Query, Resolver } from "type-graphql";
+import { Fighter } from "../../dtos/SaltyBets/Fighter";
+import { logger } from "../../../utils/logger";
+import chalk from "chalk";
+import { SaltyBetsService } from "../../../utils/salty-boy/SaltyBetsService";
+
+@Resolver(Fighter)
+export class FighterResolver {
+  @Query(() => Fighter)
+  async getFighter(@Arg("id", () => Int) id: number) {
+    logger.debug("getting fighter...");
+    const fighter = await SaltyBetsService.getFighter(id);
+    logger.info(
+      `${chalk.greenBright("Success!")} got fighter ${chalk.yellowBright(
+        fighter.name
+      )}`
+    );
+    return fighter;
+  }
+}

--- a/packages/api/src/resolvers/SaltyBets/Match.ts
+++ b/packages/api/src/resolvers/SaltyBets/Match.ts
@@ -14,6 +14,11 @@ import { SaltyBetsService } from "../../../utils/salty-boy/SaltyBetsService";
 
 @Resolver(Match)
 export class MatchResolver implements ResolverInterface<Match> {
+  /**
+   * Gets a match from the salty-boy api given an id
+   * @param id id of the match to get
+   * @returns the given match
+   */
   @Query(() => Match)
   async getMatch(@Arg("id", () => Int) id: number) {
     logger.debug("getting match...");
@@ -26,16 +31,28 @@ export class MatchResolver implements ResolverInterface<Match> {
     return match;
   }
 
+  /**
+   * Gets the blue fighter if requested
+   * @returns the given fighter
+   */
   @FieldResolver()
   async fighterBlue(@Root() match: Match) {
     return await SaltyBetsService.getFighter(match.fighterBlueId);
   }
 
+  /**
+   * Gets the red fighter if requested
+   * @returns the given fighter
+   */
   @FieldResolver()
   async fighterRed(@Root() match: Match) {
     return await SaltyBetsService.getFighter(match.fighterRedId);
   }
 
+  /**
+   * Gets the winning fighter if requested
+   * @returns the given fighter
+   */
   @FieldResolver()
   async winner(@Root() match: Match) {
     return await SaltyBetsService.getFighter(match.winnerId);

--- a/packages/api/src/resolvers/SaltyBets/Match.ts
+++ b/packages/api/src/resolvers/SaltyBets/Match.ts
@@ -1,0 +1,43 @@
+import {
+  Arg,
+  FieldResolver,
+  Int,
+  Query,
+  Resolver,
+  ResolverInterface,
+  Root,
+} from "type-graphql";
+import { logger } from "../../../utils/logger";
+import chalk from "chalk";
+import { Match } from "../../dtos/SaltyBets/Match";
+import { SaltyBetsService } from "../../../utils/salty-boy/SaltyBetsService";
+
+@Resolver(Match)
+export class MatchResolver implements ResolverInterface<Match> {
+  @Query(() => Match)
+  async getMatch(@Arg("id", () => Int) id: number) {
+    logger.debug("getting match...");
+    const match = await SaltyBetsService.getMatch(id);
+    logger.info(
+      `${chalk.greenBright("Success!")} got match ${chalk.yellowBright(
+        match.id
+      )}`
+    );
+    return match;
+  }
+
+  @FieldResolver()
+  async fighterBlue(@Root() match: Match) {
+    return await SaltyBetsService.getFighter(match.fighterBlueId);
+  }
+
+  @FieldResolver()
+  async fighterRed(@Root() match: Match) {
+    return await SaltyBetsService.getFighter(match.fighterRedId);
+  }
+
+  @FieldResolver()
+  async winner(@Root() match: Match) {
+    return await SaltyBetsService.getFighter(match.winnerId);
+  }
+}

--- a/packages/api/src/resolvers/SaltyBets/index.ts
+++ b/packages/api/src/resolvers/SaltyBets/index.ts
@@ -1,0 +1,2 @@
+export * from "./Fighter";
+export * from "./Match";

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -2,5 +2,11 @@ import { BuildSchemaOptions } from "type-graphql";
 import { PlayerResolver } from "./Player";
 import { ItemResolver } from "./Item";
 import { AuthenticationResolver } from "./Authentication";
+import * as SaltyBetsResolvers from "./SaltyBets";
 
-export const Resolvers: BuildSchemaOptions["resolvers"] = [PlayerResolver, ItemResolver, AuthenticationResolver];
+export const Resolvers: BuildSchemaOptions["resolvers"] = [
+  PlayerResolver,
+  ItemResolver,
+  AuthenticationResolver,
+  ...Object.values(SaltyBetsResolvers),
+];

--- a/packages/api/utils/salty-boy/SaltyBetsService.ts
+++ b/packages/api/utils/salty-boy/SaltyBetsService.ts
@@ -1,0 +1,14 @@
+import saltyBoy from "./saltyBoyAxiosInstance";
+import { mapToFighter, mapToMatch } from "./saltyBoyDataMapper";
+
+export class SaltyBetsService {
+  static async getFighter(id: number) {
+    const { data } = await saltyBoy.get(`fighter/${id}`);
+    return mapToFighter(data);
+  }
+
+  static async getMatch(id: number) {
+    const { data } = await saltyBoy.get(`match/${id}`);
+    return mapToMatch(data);
+  }
+}

--- a/packages/api/utils/salty-boy/saltyBoyAxiosInstance.ts
+++ b/packages/api/utils/salty-boy/saltyBoyAxiosInstance.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+import chalk from "chalk";
+import { logger } from "../logger";
+
+const saltyBoy = axios.create({
+  baseURL: "https://salty-boy.com/api/",
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+saltyBoy.interceptors.request.use(
+  (request) => {
+    logger.debug(request, chalk.greenBright("salty-boy API called"));
+    return request;
+  },
+  (error) => {
+    logger.info(error, chalk.redBright("salty-boy API request error"));
+    throw error;
+  }
+);
+
+saltyBoy.interceptors.response.use(
+  (response) => {
+    logger.debug(chalk.greenBright("salty-boy API success!"));
+    return response;
+  },
+  (error) => {
+    logger.info(error, chalk.redBright("salty-boy API response error"));
+    throw error;
+  }
+);
+
+export default saltyBoy;

--- a/packages/api/utils/salty-boy/saltyBoyDataMapper.ts
+++ b/packages/api/utils/salty-boy/saltyBoyDataMapper.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- response from the salty-boy API is not typed
+export const mapToFighter = (fighterData: any) => ({
+  bestStreak: fighterData.best_streak,
+  createdTime: new Date(fighterData.created_time),
+  elo: fighterData.elo,
+  id: fighterData.id,
+  lastUpdated: new Date(fighterData.last_updated),
+  name: fighterData.name,
+  prevTier: fighterData.prev_tier,
+  tier: fighterData.tier,
+  tierElo: fighterData.tier_elo,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- response from the salty-boy API is not typed
+export const mapToMatch = (matchData: any) => ({
+  betBlue: matchData.bet_blue,
+  betRed: matchData.bet_red,
+  colour: matchData.colour,
+  date: matchData.date,
+  fighterBlueId: matchData.fighter_blue,
+  fighterRedId: matchData.fighter_red,
+  id: matchData.id,
+  matchFormat: matchData.match_format,
+  streakBlue: matchData.streak_blue,
+  streakRed: matchData.streak_red,
+  tier: matchData.tier,
+  winnerId: matchData.winner,
+});

--- a/packages/web-app/src/gql/graphql.ts
+++ b/packages/web-app/src/gql/graphql.ts
@@ -21,7 +21,7 @@ export type Scalars = {
 export type Fighter = {
   __typename?: 'Fighter';
   bestStreak: Scalars['Int']['output'];
-  createTime: Scalars['DateTimeISO']['output'];
+  createdTime: Scalars['DateTimeISO']['output'];
   elo: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   lastUpdated: Scalars['DateTimeISO']['output'];
@@ -36,6 +36,25 @@ export type Item = {
   color?: Maybe<Scalars['String']['output']>;
   id: Scalars['Float']['output'];
   name: Scalars['String']['output'];
+};
+
+export type Match = {
+  __typename?: 'Match';
+  betBlue: Scalars['Float']['output'];
+  betRed: Scalars['Float']['output'];
+  colour: Scalars['String']['output'];
+  date: Scalars['DateTimeISO']['output'];
+  fighterBlue: Fighter;
+  fighterBlueId: Scalars['Int']['output'];
+  fighterRed: Fighter;
+  fighterRedId: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  matchFormat: Scalars['String']['output'];
+  streakBlue: Scalars['Int']['output'];
+  streakRed: Scalars['Int']['output'];
+  tier: Scalars['String']['output'];
+  winner: Fighter;
+  winnerId: Scalars['Int']['output'];
 };
 
 export type Mutation = {
@@ -78,6 +97,7 @@ export type Player = {
 export type Query = {
   __typename?: 'Query';
   getFighter: Fighter;
+  getMatch: Match;
   item: Item;
   items: Array<Item>;
   player: Player;
@@ -86,6 +106,11 @@ export type Query = {
 
 
 export type QueryGetFighterArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
+export type QueryGetMatchArgs = {
   id: Scalars['Int']['input'];
 };
 

--- a/packages/web-app/src/gql/graphql.ts
+++ b/packages/web-app/src/gql/graphql.ts
@@ -14,6 +14,21 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.This scalar is serialized to a string in ISO 8601 format and parsed from a string in ISO 8601 format. */
+  DateTimeISO: { input: any; output: any; }
+};
+
+export type Fighter = {
+  __typename?: 'Fighter';
+  bestStreak: Scalars['Int']['output'];
+  createTime: Scalars['DateTimeISO']['output'];
+  elo: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  lastUpdated: Scalars['DateTimeISO']['output'];
+  name: Scalars['String']['output'];
+  prevTier: Scalars['String']['output'];
+  tier: Scalars['String']['output'];
+  tierElo: Scalars['Int']['output'];
 };
 
 export type Item = {
@@ -62,10 +77,16 @@ export type Player = {
 
 export type Query = {
   __typename?: 'Query';
+  getFighter: Fighter;
   item: Item;
   items: Array<Item>;
   player: Player;
   players: Array<Player>;
+};
+
+
+export type QueryGetFighterArgs = {
+  id: Scalars['Int']['input'];
 };
 
 


### PR DESCRIPTION
Resolves #26 
Add axios to send network requests to salty-boy api
Add service to send network requests to the salty-boy api
Add data mappers to map salty-boy responses to expected outputs
Add DTO's for matches and fighters
Add Resolvers to manage getting matches and fighters from the salty-boy API